### PR TITLE
Notify observers when new theme is set

### DIFF
--- a/Theme.podspec
+++ b/Theme.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Theme"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary      = "Support one or more configurable appearance themes."
   s.author       = 'Hilton Campbell'
   s.homepage     = "https://github.com/CrossWaterBridge/Theme"

--- a/Theme.podspec
+++ b/Theme.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name         = "Theme"
-  s.version      = "3.0.1"
+  s.version      = "3.1.0"
   s.summary      = "Support one or more configurable appearance themes."
-  s.author       = 'Hilton Campbell'
+  s.author       = 'Hilton Campbell', 'Stephan Heilner'
   s.homepage     = "https://github.com/CrossWaterBridge/Theme"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.source       = { :git => "https://github.com/CrossWaterBridge/Theme.git", :tag => s.version.to_s }

--- a/Theme/ThemeController.swift
+++ b/Theme/ThemeController.swift
@@ -39,6 +39,8 @@ public class ThemeController: NSObject {
         self.theme = theme
         
         theme.setTheme(themeName: themeName)
+        
+        themeObservers.notify()
     }
     
     let themeObservers = ObserverSet<Void>()

--- a/Theme/ThemeController.swift
+++ b/Theme/ThemeController.swift
@@ -35,7 +35,7 @@ public class ThemeController: NSObject {
         }
     }
     
-    public func registerTheme(_ theme: Theme.Type) {
+    public func setTheme(_ theme: Theme.Type) {
         self.theme = theme
         
         theme.setTheme(themeName: themeName)

--- a/ThemeDemo/AppDelegate.swift
+++ b/ThemeDemo/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        ThemeController.shared.registerTheme(DemoTheme.self)
+        ThemeController.shared.setTheme(DemoTheme.self)
         
         let viewController = ViewController(appSettings: appSettings)
         let navigationController = ThemeAwareNavigationController(rootViewController: viewController)


### PR DESCRIPTION
Any views set to observe theme changes before registerTheme is called, won't have been notified that a theme was set, and won't have the right colors. Storyboards, for example, will initialize views before even the first line of `application(_ application: UIApplication, willFinishLaunchingWithOptions...` is called.