### PR TITLE
Execute  when registering observeTheme for UIView/UIViewCOntroller

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Signals (6.0.0)
-  - Theme (5.0.0):
+  - Theme (5.0.1):
     - Signals
 
 DEPENDENCIES:
@@ -21,8 +21,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Signals: 71e3b5832062e61d3703d6d5a760c3fafb637c0e
-  Theme: 975483eb6abd8cd8872cdd0549e986f1dd6a92e8
+  Theme: aa68f2be18e2f1879f2d501aee2764a642846445
 
 PODFILE CHECKSUM: 3e752682c594be31df507aa7e214e18971381922
 
-COCOAPODS: 1.6.0.rc.1
+COCOAPODS: 1.6.0.rc.2

--- a/Theme.podspec
+++ b/Theme.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Theme"
-  s.version      = "5.0.0"
+  s.version      = "5.0.1"
   s.summary      = "Support one or more configurable appearance themes."
   s.author       = 'Hilton Campbell', 'Stephan Heilner'
   s.homepage     = "https://github.com/CrossWaterBridge/Theme"

--- a/Theme/ThemeObserver.swift
+++ b/Theme/ThemeObserver.swift
@@ -27,11 +27,13 @@ public protocol ThemeObserver {}
 extension ThemeObserver where Self: UIView {
     public func observeTheme(_ callback: @escaping () -> Void) {
         ThemeController.shared.themeObservers.subscribe(with: self, callback: callback)
+        callback()
     }
 }
 
 extension ThemeObserver where Self: UIViewController {
     public func observeTheme(_ callback: @escaping () -> Void) {
         ThemeController.shared.themeObservers.subscribe(with: self, callback: callback)
+        callback()
     }
 }


### PR DESCRIPTION
This fixes a bug that wasn't calling themeDidChange when registering to observeTheme.